### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build & Publish API to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: galaxyfuture/bridgx-api
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/checkout@master
       - name: Build & Publish Scheduler to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: galaxyfuture/bridgx-scheduler
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/checkout@master
       - name: Build & Publish API to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: galaxyfuture/bridgx-api
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/checkout@master
       - name: Build & Publish Scheduler to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: galaxyfuture/bridgx-scheduler
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore